### PR TITLE
[README.md] Unraid Setup update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,22 @@ Rescan the plugins, you will find a new button in the `Tasks` sections in the se
 
 # Setup on Unraid
 
-Use a normal ssh session to your unraid server. or if you really want then use the webui to get to stash's console and start at the second line.
+SSH to your server or if you use the webui to open Stash's console then start at the second line.
 
-```
-docker exec -i -t Stash bash
-apt-get update
-apt-get install git
+```sh
+docker exec -i -t Stash sh
+apk update
+apk add git
 cd /root/.stash/plugins/
 git clone https://github.com/com1234475/stash-plugin-performer-creator.git
-apt-get install virtualenv
-virtualenv -p python3 --system-site-packages /root/.stash/plugins/env
-source /root/.stash/plugins/env/bin/activate
-python -m pip install spacy==2.3.5
-python -m pip install requests
+cd stash-plugin-performer-creator/
+###
+# dont know if subversion/python3-dev is needed but this worked.
+###
+apk add make automake gcc g++ subversion python3-dev
+python3 -m venv env
+source env/bin/activate
+python -m pip install -r requirements.txt
 python -m spacy download en_core_web_md
 ```
 


### PR DESCRIPTION
updated unraid setup instructions in readme. 
stash docker is now on alpine. no more apt-get. no more bash. many errors trying to install spacy (gcc/make).